### PR TITLE
Some improvements to the Rust version

### DIFF
--- a/examples/rust-parallel-example/benches/binary-tree.rs
+++ b/examples/rust-parallel-example/benches/binary-tree.rs
@@ -1,17 +1,22 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
-use parallel_example::{sum, sum_rayon, make_balanced_tree};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use parallel_example::{make_balanced_tree, sum, sum_rayon};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    for &n in [1000, 100_000_000].iter() {
+    for n in [1000, 100_000_000] {
         let mut group = c.benchmark_group(format!("tree-sum-{}", n));
         group.sample_size(50);
         let root = make_balanced_tree(1, n);
-        group.bench_with_input(BenchmarkId::new("Baseline", 1), &1,
-            |b, _i| b.iter(|| sum(black_box(&root))));
-        for &num_threads in [1, 2, 4, 8, 16, 32].iter() {
-            let pool = rayon::ThreadPoolBuilder::new().num_threads(num_threads).build().unwrap();
-            group.bench_with_input(BenchmarkId::new("Rayon", num_threads), &num_threads,
-                |b, _i| b.iter(|| sum_rayon(&pool, black_box(&root))));
+        group.bench_with_input(BenchmarkId::new("Baseline", 1), &root, |b, root| {
+            b.iter(|| sum(root))
+        });
+        for num_threads in [1, 2, 4, 8, 16, 32] {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build()
+                .unwrap();
+            group.bench_with_input(BenchmarkId::new("Rayon", num_threads), &root, |b, root| {
+                b.iter(|| sum_rayon(&pool, root))
+            });
         }
     }
 }

--- a/examples/rust-parallel-example/benches/binary-tree.rs
+++ b/examples/rust-parallel-example/benches/binary-tree.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
-use rayon;
 use parallel_example::{sum, sum_rayon, make_balanced_tree};
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/examples/rust-parallel-example/benches/binary-tree.rs
+++ b/examples/rust-parallel-example/benches/binary-tree.rs
@@ -1,13 +1,13 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use parallel_example::{make_balanced_tree, sum, sum_rayon};
+use parallel_example::Node;
 
 fn criterion_benchmark(c: &mut Criterion) {
     for n in [1000, 100_000_000] {
         let mut group = c.benchmark_group(format!("tree-sum-{}", n));
         group.sample_size(50);
-        let root = make_balanced_tree(1, n);
+        let root = Node::make_balanced_tree(1, n);
         group.bench_with_input(BenchmarkId::new("Baseline", 1), &root, |b, root| {
-            b.iter(|| sum(root))
+            b.iter(|| root.sum())
         });
         for num_threads in [1, 2, 4, 8, 16, 32] {
             let pool = rayon::ThreadPoolBuilder::new()
@@ -15,7 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 .build()
                 .unwrap();
             group.bench_with_input(BenchmarkId::new("Rayon", num_threads), &root, |b, root| {
-                b.iter(|| sum_rayon(&pool, root))
+                b.iter(|| root.sum_rayon(&pool))
             });
         }
     }

--- a/examples/rust-parallel-example/src/lib.rs
+++ b/examples/rust-parallel-example/src/lib.rs
@@ -5,12 +5,12 @@ pub struct Node<T> {
 }
 
 pub fn make_balanced_tree(from: i64, to: i64) -> Node<i64> {
-    let value = from + (to-from)/2;
-    return Node {
-        value: value,
+    let value = from + (to - from) / 2;
+    Node {
+        value,
         left: (value > from).then(|| Box::new(make_balanced_tree(from, value - 1))),
         right: (value < to).then(|| Box::new(make_balanced_tree(value + 1, to))),
-    };
+    }
 }
 
 pub fn sum(node: &Node<i64>) -> i64 {
@@ -21,15 +21,13 @@ pub fn sum(node: &Node<i64>) -> i64 {
     if let Some(child) = &node.right {
         result += sum(child);
     }
-    return result;
+    result
 }
 
 pub fn sum_rayon(pool: &rayon::ThreadPool, node: &Node<i64>) -> i64 {
     if let (Some(left), Some(right)) = (&node.left, &node.right) {
-        let (left_result, right_result) = pool.join(
-            || sum_rayon(pool, left),
-            || sum_rayon(pool, right),
-        );
+        let (left_result, right_result) =
+            pool.join(|| sum_rayon(pool, left), || sum_rayon(pool, right));
         return node.value + left_result + right_result;
     }
 
@@ -40,5 +38,5 @@ pub fn sum_rayon(pool: &rayon::ThreadPool, node: &Node<i64>) -> i64 {
     if let Some(child) = &node.right {
         result += sum_rayon(pool, child);
     }
-    return result;
+    result
 }

--- a/examples/rust-parallel-example/src/lib.rs
+++ b/examples/rust-parallel-example/src/lib.rs
@@ -1,10 +1,10 @@
-pub struct Node<T> {
-    value: T,
-    left: Option<Box<Node<T>>>,
-    right: Option<Box<Node<T>>>,
+pub struct Node {
+    value: i64,
+    left: Option<Box<Node>>,
+    right: Option<Box<Node>>,
 }
 
-pub fn make_balanced_tree(from: i64, to: i64) -> Node<i64> {
+pub fn make_balanced_tree(from: i64, to: i64) -> Node {
     let value = from + (to - from) / 2;
     Node {
         value,
@@ -13,7 +13,7 @@ pub fn make_balanced_tree(from: i64, to: i64) -> Node<i64> {
     }
 }
 
-pub fn sum(node: &Node<i64>) -> i64 {
+pub fn sum(node: &Node) -> i64 {
     let mut result = node.value;
     if let Some(child) = &node.left {
         result += sum(child);
@@ -24,7 +24,7 @@ pub fn sum(node: &Node<i64>) -> i64 {
     result
 }
 
-pub fn sum_rayon(pool: &rayon::ThreadPool, node: &Node<i64>) -> i64 {
+pub fn sum_rayon(pool: &rayon::ThreadPool, node: &Node) -> i64 {
     if let (Some(left), Some(right)) = (&node.left, &node.right) {
         let (left_result, right_result) =
             pool.join(|| sum_rayon(pool, left), || sum_rayon(pool, right));


### PR DESCRIPTION
* Fix clippy warnings
    These are just linter warnings about unidiomatic/unnecessary code, should be pretty harmless to apply.

* Remove `Node<T>` generic
    This isn't supposed to change the compiled output (and at least on the stripped down version hosted on godbolt it didn't). Just making the Rust version match more 1:1 with the Zig version to remove some distractions.

* Cleanup benchmark script
    The main thing is that the purpose of `bench_with_input` is to automatically wrap the input in `black_box`, so it was needlessly double-wrapped.

* Make the two versions more identical
    The previous `sum_rayon` version has a extra check for `(left && right)` that made the code substantially different than the plain version, at least visually.

    This changes the implementations on both sides to match and also IMO a bit more idiomatic.

* Make sum a method
    This matches the Zig version a bit closer in the source code, and is IMO more idiomatic, but it shouldn't really change the compiled output.

I did make some (lousy) effort to make sure none of these _obviously_ caused any regression (it may be slightly faster?), but I was just running it on my laptop with a ton of browser tabs open, etc, etc. So probably should double check that in your benchmark environment.