### PR TITLE
Replace `@setCold` with `@branchHint`

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -184,7 +184,7 @@ pub const ThreadPool = struct {
 
     /// The core logic of the heartbeat. Every executing worker invokes this periodically.
     fn heartbeat(self: *ThreadPool, worker: *Worker) void {
-        @setCold(true);
+        @branchHint(.cold);
 
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -527,7 +527,7 @@ pub fn Future(comptime Input: type, Output: type) type {
         }
 
         fn joinExecuting(self: *Self, task: *Task) ?Output {
-            @setCold(true);
+            @branchHint(.cold);
 
             const w = task.worker;
             const pool = w.pool;


### PR DESCRIPTION
This commit updates the usage of `@setCold(true)` to the new `@branchHint(.cold)` in the `ThreadPool` and `Future` implementations, following the latest API changes in Zig's nightly builds (v0.14.0-dev). The change ensures compatibility with the ongoing updates to the branch hinting system.

- Tested on `zig@v0.14.0-dev.1913+7b8fc18c6`.
- Related PR: [#21191](https://github.com/ziglang/zig/pull/21191)