### PR TITLE
Remove redundant @ptrCast

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -423,7 +423,7 @@ const Job = struct {
         std.debug.assert(tail.* == self);
         const prev: *Job = @ptrCast(@alignCast(self.prev_or_null));
         prev.next_or_state = null; // prev.next = null
-        tail.* = @ptrCast(@alignCast(self.prev_or_null)); // tail = self.prev
+        tail.* = prev; // tail = self.prev
         self.* = undefined;
     }
 


### PR DESCRIPTION
This removes a redundant `@ptrCast(@alignCast(...))` call. In `ReleaseFast` optimize mode, it saves one instruction (on x86_64).